### PR TITLE
Exit loop on build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,14 @@ build-release:
 	fi
 	@for OS in linux darwin windows; do for ARCH in amd64 arm64; do \
 			echo "# Building $${OS}-$${ARCH}-$(BINARY_NAME)"; \
-			GOOS=$${OS} GOARCH=$${ARCH} CGO_ENABLED=0 go build -mod=readonly -ldflags="$(GO_LDFLAGS)" -o $(BUILD_DIR)/$${OS}-$${ARCH}-$(BINARY_NAME) ./cmd/$(BINARY_NAME); \
+			GOOS=$${OS} GOARCH=$${ARCH} CGO_ENABLED=0 \
+				go build -mod=readonly -ldflags="$(GO_LDFLAGS)" -o $(BUILD_DIR)/$${OS}-$${ARCH}-$(BINARY_NAME) ./cmd/$(BINARY_NAME) \
+				|| exit 1; \
 		done; done
 	# Adding .exe extension to Windows binaries
 	@for FILE in $$(ls -1 $(BUILD_DIR)/windows-* | grep -v ".exe$$"); do \
-		mv $${FILE} $${FILE}.exe; \
+		mv $${FILE} $${FILE}.exe \
+		|| exit 1; \
 	done
 
 .PHONY: build-oc-plugin


### PR DESCRIPTION
Since the loop is technically working, it doesn't short-circuit Make.