### PR TITLE
Use bot token for PR

### DIFF
--- a/.github/workflows/package-update.yml
+++ b/.github/workflows/package-update.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Open update PR
         if: ${{ env.OPEN_PR == 'true' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           # Setup user
           git config user.name "acm-grc-security[bot]"


### PR DESCRIPTION
Without it, the default token, logically, isn't able to trigger actions in the new PR.

ref: https://github.com/cli/cli/discussions/6575
