### PR TITLE
Update workflow to sync previous releases

### DIFF
--- a/.github/workflows/package-update.yml
+++ b/.github/workflows/package-update.yml
@@ -6,14 +6,35 @@ on:
     - cron: 0 0 * * 1
 
 jobs:
-  dependencies:
+  setup:
+    name: Fetch versions
     runs-on: ubuntu-latest
-    name: Check
+    outputs:
+      versionMatrix: ${{ steps.fetchVersions.outputs.versions }}
+    steps:
+      - id: fetchVersions
+        run: |
+          versions=$(
+            echo "main"
+            curl -s https://raw.githubusercontent.com/stolostron/governance-policy-framework/refs/heads/main/CURRENT_SUPPORTED_VERSIONS | sed 's/^/release-/g'
+          )
+          echo "Found versions: "${versions}
+          versions_json="{\"version\":[\"${versions//[[:space:]]/\",\"}\"]}"
+          echo "Created JSON: ${versions_json}"
+          echo "versions=${versions_json}" >> $GITHUB_OUTPUT
+
+  dependencies:
+    name: Update
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.versionMatrix) }}
     steps:
       - name: Checkout policy-cli Repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ matrix.version }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -22,13 +43,16 @@ jobs:
 
       - name: Check for package upgrades
         run: |
-          packages=$(
-            go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all |
-              grep "stolostron\|open-cluster-management.io"
-            )
-          for pkg in ${packages}; do
-            go get ${pkg}@main
-          done
+          # Go Template Utils
+          go get $(awk '/github.com\/stolostron\/go-template-utils/ {print $1}' go.mod)@${{ matrix.version }}
+
+          # ConfigurationPolicy Controller
+          if [[ ${{ matrix.version }} == "main" ]]; then
+            go get open-cluster-management.io/config-policy-controller@${{ matrix.version }}
+          else
+            go mod edit -replace open-cluster-management.io/config-policy-controller=github.com/stolostron/config-policy-controller@${{ matrix.version }}
+          fi
+
           go mod tidy
           git diff --exit-code || echo "OPEN_PR=true" >> ${GITHUB_ENV}
 
@@ -41,8 +65,10 @@ jobs:
           git config user.name "acm-grc-security[bot]"
           git config user.email "acm-grc-security[bot]@users.noreply.github.com"
 
-          git checkout -b gh-action-pkg-update
-          git commit -s -am "Update subcommand packages"
-          git push --delete origin gh-action-pkg-update || true
-          git push origin gh-action-pkg-update
+          branch=gh-action-pkg-update-${{ matrix.version }}
+
+          git checkout -b ${branch}
+          git commit -s -am "[${{ matrix.version }}] Update subcommand packages"
+          git push --delete origin ${branch} || true
+          git push origin ${branch}
           gh pr create --fill

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ The `policytools` CLI is a toolset that helps you manage policies in the multicl
 environments managed by Red Hat Advanced Cluster Management. They're made available through the
 [`acm-cli`](https://github.com/stolostron/acm-cli) repository.
 
-# Usage
+## Usage
 
 <!--BEGINHELP-->
 
-```
+```text
 Red Hat Advanced Cluster Management Policy Toolset
 
 This toolset helps you manage the policies in multicluster Kubernetes
@@ -62,11 +62,13 @@ oc policytools
 
 ### Using Go
 
-Replace `main` with a `release-*` branch to build a particular version:
+```bash
+go install github.com/stolostron/policy-cli/cmd/policytools@latest
+```
 
-```
-go install github.com/stolostron/policy-cli/cmd/policytools@main
-```
+**NOTE:** To build a particular release, clone this repository, check out the `release-*` branch,
+and run `go install ./cmd/policytools`. This is necessary because previous releases typically have a
+`replace` statement in the `go.mod`.
 
 ### Using Make targets
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -15,7 +15,7 @@ testDiff() {
 
 validate-readme() {
   echo '# Validating content difference between README.md and `policytools --help`'
-  updated_readme="$(printf '<!--BEGINHELP-->\n\n```\n%s\n```\n\n<!--ENDHELP-->\n' "$(${TEST_DIR}/../build/_output/policytools)")"
+  updated_readme="$(printf '<!--BEGINHELP-->\n\n```text\n%s\n```\n\n<!--ENDHELP-->\n' "$(${TEST_DIR}/../build/_output/policytools)")"
   current_readme="$(awk '/<!--BEGINHELP-->/,/<!--ENDHELP-->/' README.md)"
   testDiff "${updated_readme}" "${current_readme}"
 }


### PR DESCRIPTION
- Pulls the release branches from governance-policy-framework to populate the workflow matrix.
- Iterates over the branches, opening PRs with updates if changes are made, adding `stolostron` "replace" statements for config-policy backports.
- Updates the README since with the `replace`, release branches will no longer be able to be `go install`-ed.

Sample PR:
- https://github.com/stolostron/policy-cli/pull/51