### PR TITLE
[release-2.14] chore: sync common makefiles for go 1.26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: cron
       cronjob: "0 7 * * MON#1"
       timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
     groups:
       github-actions:
         patterns:
@@ -16,6 +20,10 @@ updates:
       interval: cron
       cronjob: "0 7 * * MON#1"
       timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
     groups:
       gomod:
         patterns:

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -7,7 +7,7 @@ CONTROLLER_GEN_VERSION := v0.19.0
 # https://github.com/kubernetes-sigs/kustomize/releases/latest
 KUSTOMIZE_VERSION := v5.7.1
 # https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_VERSION := v2.4.0
+GOLANGCI_VERSION := v2.12.2
 # https://github.com/mvdan/gofumpt/releases/latest
 GOFUMPT_VERSION := v0.9.1
 # https://github.com/daixiang0/gci/releases/latest

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -87,7 +87,6 @@ linters:
       - std-error-handling
     rules:
       - linters:
-          - golint
           - revive
           - staticcheck
         path: _test\.go$|^test/

--- a/pkg/policytools/policytools.go
+++ b/pkg/policytools/policytools.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stolostron/policy-cli/internal"
 )
 
-// policyCmd represents the base command when called without any subcommands
+// Cmd represents the base command when called without any subcommands.
 type Cmd struct{}
 
 func (a Cmd) GetCmd() *cobra.Command {


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/ACM-35531